### PR TITLE
fix: specify exact versions for pipreqs and GitPython in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ readme = "README.md"
 requires-python = ">=3.12"
 dynamic = ["version"]
 dependencies = [
-    "pipreqs"
+    "pipreqs==0.5.0",
+    "GitPython==3.1.44"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Task

# Description

<!--- START AUTOGENERATED NOTES --->
# Contents ([#50](https://github.com/jfheinrich-eu/pipreqs-action/pull/50))

### Other
- specify exact versions for pipreqs and GitPython in dependencies

<!--- END AUTOGENERATED NOTES --->


# Demo

# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes